### PR TITLE
Remove epoll usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Johann Tuffe <tafia973@gmail.com>"]
 description = "A driver for DHT11 temperature and humidity sensor"
 
 [dependencies]
-sysfs_gpio = "0.4.4"
-error-chain = "0.6.2"
+# cupi = { git = "https://github.com/inre/cupi" }
+cupi = "0.1.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,25 +1,20 @@
+#[derive(Debug)]
+pub enum Error {
+    Gpio(::cupi::Error),
+    Time(::std::time::SystemTimeError),
+    TimeOut
+}
 
-#![allow(missing_docs)]
+pub type Result<T> = ::std::result::Result<T, Error>;
 
-error_chain! {
-    types {
-        Error, ErrorKind, Result;
+impl From<::cupi::Error> for Error {
+    fn from(error: ::cupi::Error) -> Error {
+        Error::Gpio(error)
     }
+}
 
-//     links {
-//         rustup_dist::Error, rustup_dist::ErrorKind, Dist;
-//         rustup_utils::Error, rustup_utils::ErrorKind, Utils;
-//     }
-
-    foreign_links {
-        ::sysfs_gpio::Error, Gpio;
-        ::std::time::SystemTimeError, Time;
+impl From<::std::time::SystemTimeError> for Error {
+    fn from(error: ::std::time::SystemTimeError) -> Error {
+        Error::Time(error)
     }
-
-//     errors {
-//         InvalidToolchainName(t: String) {
-//             description("invalid toolchain name")
-//             display("invalid toolchain name: '{}'", t)
-//         }
-//     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,8 @@ extern crate error_chain;
 
 mod errors;
 
-use sysfs_gpio::{Pin, Direction, Edge};
+use sysfs_gpio::{Pin, Direction};
+use sysfs_gpio::Error::Unexpected;
 use std::thread;
 use std::time::{Duration, SystemTime};
 use errors::*;
@@ -25,7 +26,7 @@ impl DHT11 {
     /// Reads humidity and temperature
     pub fn read(&mut self) -> Result<Response> {
 
-        let mut times = Vec::with_capacity(41);
+        let mut times = Vec::with_capacity(40);
         self.pin.with_exported(|| {
 
             // send init signal
@@ -36,38 +37,62 @@ impl DHT11 {
             thread::sleep(Duration::new(0, 40_000));
 
             // getting sensor data
-            let start = SystemTime::now();
-            let mut poller = self.pin.get_poller()?;
             self.pin.set_direction(Direction::In)?;
-            self.pin.set_edge(Edge::FallingEdge)?;
-            while poller.poll(1)?.is_some() {
-                times.push(start.elapsed().unwrap());
+            self.next_period_ns(80_000, 80_000)?; // init response
+            for _ in 0..40 {
+                times.push(self.next_period_ns(50_000, 26_000)?); // bit data
             }
             Ok(())
+
         })?;
 
         // convert times to bytes
-        let mut intervals = times.windows(2).map(|w| w[1] - w[0]);
         let mut bytes = [0u8; 5];
-        for val in bytes.iter_mut() {
-            for i in intervals.by_ref().take(8) {
+        for (val, ch) in bytes.iter_mut().zip(times.chunks(8)) {
+            for t in ch {
                 *val <<= 1;
-                if i > Duration::new(0, 80_000) { *val |= 1; }
+                if *t > 100_000 { *val |= 1; }
             }
         }
 
         // checksum
-        // let sum: u16 = bytes.iter().take(4).map(|b| *b as u16).sum();
-        // if bytes[4] as u16 != sum & 0x00FF {
-        //     Err("Invalid checksum".into())
-        // } else {
+        let sum: u16 = bytes.iter().take(4).map(|b| *b as u16).sum();
+        if bytes[4] as u16 != sum & 0x00FF {
+            Err("Invalid checksum".into())
+        } else {
             Ok(Response {
                 h_int: bytes[0],
                 h_dec: bytes[1],
                 t_int: bytes[2],
                 t_dec: bytes[3],
             })
-        //}
+        }
+    }
+
+    /// Measures the duration in nanoseconds of a period with indicative low and high durations
+    fn next_period_ns(&self, low_ns: u32, high_ns: u32) -> ::sysfs_gpio::Result<u32> {
+        let start = SystemTime::now();
+        let mut val = 0u8;
+        let mut counter = 0u8;
+        for dt in [low_ns, high_ns].iter() {
+            // make sure we're at same value at half semi-period
+            thread::sleep(Duration::new(0, dt / 2));
+            if self.pin.get_value()? != val {
+                return Err(Unexpected(format!("Expecting {} value", val)));
+            }
+            thread::sleep(Duration::new(0, dt / 2));
+            let target = 1 - val;
+            val = self.pin.get_value()?;
+            while val != target {
+                thread::sleep(Duration::new(0, 1000));
+                counter += 1;
+                if counter == 255 { // a period cannot exceed 255 microseconds
+                    return Err(Unexpected("Timeout".to_string()));
+                }
+                val = self.pin.get_value()?;
+            }
+        }
+        Ok(start.elapsed().unwrap().subsec_nanos())
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,89 +26,77 @@ impl DHT11 {
     /// Reads humidity and temperature
     pub fn read(&mut self) -> Result<Response> {
 
-        let mut times = Vec::with_capacity(40);
-        self.pin.with_exported(|| {
+        let mut intervals = [0; 40];
+        if let Err(e) = self.pin.with_exported(|| {
 
             // send init signal
-            self.pin.set_direction(Direction::Low)?;
+            self.pin.set_direction(Direction::Out)?;
             self.pin.set_value(0)?;
-            thread::sleep(Duration::from_millis(18));
+            thread::sleep(Duration::new(0, 18_000_000));
             self.pin.set_value(1)?;
             thread::sleep(Duration::new(0, 40_000));
 
-            // getting sensor data
+            // getting sensor response
             self.pin.set_direction(Direction::In)?;
-            self.next_period_ns(80_000, 80_000)?; // init response
-            for _ in 0..40 {
-                times.push(self.next_period_ns(50_000, 26_000)?); // bit data
+            self.next_pulse(0)?;
+            self.next_cycle_ns(80_000, 80_000)?; // init response
+
+            // 40 bit data
+            for t in intervals.iter_mut() {
+                *t = self.next_cycle_ns(50_000, 26_000)?; // bit data
             }
             Ok(())
 
-        })?;
+        }) {
+            println!("intervals: {:?}", intervals.as_ref());
+            return Err(e.into());
+        }
 
-        // convert times to bytes
+        // convert intervals to bytes
         let mut bytes = [0u8; 5];
-        for (val, ch) in bytes.iter_mut().zip(times.chunks(8)) {
+        for (val, ch) in bytes.iter_mut().zip(intervals.chunks(8)) {
             for t in ch {
                 *val <<= 1;
                 if *t > 100_000 { *val |= 1; }
             }
         }
 
-        // checksum
-        let sum: u16 = bytes.iter().take(4).map(|b| *b as u16).sum();
-        if bytes[4] as u16 != sum & 0x00FF {
-            Err("Invalid checksum".into())
-        } else {
-            Ok(Response {
-                h_int: bytes[0],
-                h_dec: bytes[1],
-                t_int: bytes[2],
-                t_dec: bytes[3],
-            })
-        }
+        Ok(Response { bytes: bytes })
     }
 
-    /// Measures the duration in nanoseconds of a period with indicative low and high durations
-    fn next_period_ns(&self, low_ns: u32, high_ns: u32) -> ::sysfs_gpio::Result<u32> {
-        let start = SystemTime::now();
-        let mut val = 0u8;
-        let mut counter = 0u8;
-        for dt in [low_ns, high_ns].iter() {
-            // make sure we're at same value at half semi-period
-            thread::sleep(Duration::new(0, dt / 2));
-            if self.pin.get_value()? != val {
-                return Err(Unexpected(format!("Expecting {} value", val)));
-            }
-            thread::sleep(Duration::new(0, dt / 2));
-            let target = 1 - val;
-            val = self.pin.get_value()?;
-            while val != target {
-                thread::sleep(Duration::new(0, 1000));
-                counter += 1;
-                if counter == 255 { // a period cannot exceed 255 microseconds
-                    return Err(Unexpected("Timeout".to_string()));
-                }
-                val = self.pin.get_value()?;
-            }
+    fn next_pulse(&self, level: u8) -> ::sysfs_gpio::Result<()> {
+        for _ in 0..500 {
+            if self.pin.get_value()? == level { return Ok(()); }
+            thread::sleep(Duration::new(0, 1000));
         }
+        Err(Unexpected("Timeout".to_string()))
+    }
+
+    /// Measures the duration in nanoseconds of a cycle with indicative low and high durations
+    fn next_cycle_ns(&self, low_ns: u32, high_ns: u32) -> ::sysfs_gpio::Result<u32> {
+        let start = SystemTime::now();
+        thread::sleep(Duration::new(0, low_ns * 3 / 4));
+        self.next_pulse(1)?;
+        thread::sleep(Duration::new(0, high_ns * 3 / 4));
+        self.next_pulse(0)?;
         Ok(start.elapsed().unwrap().subsec_nanos())
     }
 
 }
 
 pub struct Response {
-    h_int: u8,
-    h_dec: u8,
-    t_int: u8,
-    t_dec: u8,
+    bytes: [u8; 5]
 }
 
 impl Response {
+    pub fn is_valid(&self) -> bool {
+        let sum: u16 = self.bytes.iter().take(4).map(|b| *b as u16).sum();
+        self.bytes[4] as u16 == sum & 0x00FF
+    }
     pub fn get_temperature(&self) -> f32 {
-        self.t_int as f32 + self.t_dec as f32 / 1000.
+        self.bytes[2] as f32 + self.bytes[3] as f32 / 1000.
     }
     pub fn get_humidity(&self) -> f32 {
-        self.h_int as f32 + self.h_dec as f32 / 1000.
+        self.bytes[0] as f32 + self.bytes[1] as f32 / 1000.
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate error_chain;
 
 mod errors;
 
-use sysfs_gpio::{Pin, PinPoller, Direction, Edge};
+use sysfs_gpio::{Pin, Direction, Edge};
 use std::thread;
 use std::time::{Duration, SystemTime};
 use errors::*;
@@ -22,43 +22,52 @@ impl DHT11 {
         }
     }
 
+    /// Reads humidity and temperature
     pub fn read(&mut self) -> Result<Response> {
-        self.pin.set_edge(Edge::BothEdges)?;
-        let mut poller = self.pin.get_poller()?;
 
-        // send init signal
-        self.pin.set_direction(Direction::Out)?;
-        self.pin.set_value(0)?;
-        thread::sleep(Duration::from_millis(18));
-        self.pin.set_value(1)?;
-        thread::sleep(Duration::new(0, 40000)); // wait 40us
+        let mut times = Vec::with_capacity(41);
+        self.pin.with_exported(|| {
 
-        // getting init response
-        self.pin.set_direction(Direction::In)?;
-        for _ in 0..3 {
-            if poller.poll(1)?.is_none() {
-                return Err("Initialization failed, device did not answer on time".into());
+            // send init signal
+            self.pin.set_direction(Direction::Low)?;
+            self.pin.set_value(0)?;
+            thread::sleep(Duration::from_millis(18));
+            self.pin.set_value(1)?;
+            thread::sleep(Duration::new(0, 40_000));
+
+            // getting sensor data
+            let start = SystemTime::now();
+            let mut poller = self.pin.get_poller()?;
+            self.pin.set_direction(Direction::In)?;
+            self.pin.set_edge(Edge::FallingEdge)?;
+            while poller.poll(1)?.is_some() {
+                times.push(start.elapsed().unwrap());
+            }
+            Ok(())
+        })?;
+
+        // convert times to bytes
+        let mut intervals = times.windows(2).map(|w| w[1] - w[0]);
+        let mut bytes = [0u8; 5];
+        for val in bytes.iter_mut() {
+            for i in intervals.by_ref().take(8) {
+                *val <<= 1;
+                if i > Duration::new(0, 80_000) { *val |= 1; }
             }
         }
 
-        // getting sensor data
-        let mut bytes = [0u8; 5];
-        for b in &mut bytes {
-            *b = read_byte(&mut poller)?;
-        }
-
         // checksum
-        let sum: u16 = bytes.iter().take(4).map(|b| *b as u16).sum();
-        if bytes[4] as u16 != sum & 0x00FF {
-            Err("Invalid checksum".into())
-        } else {
+        // let sum: u16 = bytes.iter().take(4).map(|b| *b as u16).sum();
+        // if bytes[4] as u16 != sum & 0x00FF {
+        //     Err("Invalid checksum".into())
+        // } else {
             Ok(Response {
                 h_int: bytes[0],
                 h_dec: bytes[1],
                 t_int: bytes[2],
                 t_dec: bytes[3],
             })
-        }
+        //}
     }
 
 }
@@ -76,32 +85,5 @@ impl Response {
     }
     pub fn get_humidity(&self) -> f32 {
         self.h_int as f32 + self.h_dec as f32 / 1000.
-    }
-}
-
-fn read_byte(poller: &mut PinPoller) -> Result<u8> {
-    let mut val = 0u8;
-    for _ in 0..8 {
-        val <<= 1;
-        let start = SystemTime::now();
-        if poller.poll(1)?.is_none() || start.elapsed()?.subsec_nanos() > 60000 {
-            return Err("Cannot get value, device did not answer on time".into());
-        }
-        match poller.poll(1)? {
-            None => return Err("Cannot get value, device did not answer on time".into()),
-            Some(_) => match start.elapsed()?.subsec_nanos() {
-                70000...85000 => (), // false (should be 76us to 78us), do nothing
-                110000...130000 => val |= 1, // true, should be 120us
-                _ => return Err("Cannot get value, device did not answer on time".into()),
-            }
-        }
-    }
-    Ok(val)
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use sysfs_gpio::{Pin, Direction};
 use sysfs_gpio::Error::Unexpected;
 use std::thread;
 use std::time::{Duration, SystemTime};
-use errors::*;
 
 pub struct DHT11 {
     pin: Pin,
@@ -24,7 +23,7 @@ impl DHT11 {
     }
 
     /// Reads humidity and temperature
-    pub fn read(&mut self) -> Result<Response> {
+    pub fn read(&mut self) -> errors::Result<Response> {
 
         let mut intervals = [0; 40];
         if let Err(e) = self.pin.with_exported(|| {
@@ -65,7 +64,7 @@ impl DHT11 {
     }
 
     fn next_pulse(&self, level: u8) -> ::sysfs_gpio::Result<()> {
-        for _ in 0..500 {
+        for _ in 0..200 {
             if self.pin.get_value()? == level { return Ok(()); }
             thread::sleep(Duration::new(0, 1000));
         }
@@ -75,9 +74,9 @@ impl DHT11 {
     /// Measures the duration in nanoseconds of a cycle with indicative low and high durations
     fn next_cycle_ns(&self, low_ns: u32, high_ns: u32) -> ::sysfs_gpio::Result<u32> {
         let start = SystemTime::now();
-        thread::sleep(Duration::new(0, low_ns * 3 / 4));
+        thread::sleep(Duration::new(0, low_ns / 2));
         self.next_pulse(1)?;
-        thread::sleep(Duration::new(0, high_ns * 3 / 4));
+        thread::sleep(Duration::new(0, high_ns / 2));
         self.next_pulse(0)?;
         Ok(start.elapsed().unwrap().subsec_nanos())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,9 @@ impl DHT11 {
         {
             let mut input = self.pin.input();
             next_pulse(&mut input, Logic::Low)?;
-            next_cycle_ns(&mut input, 80_000, 80_000)?; // init response
+            next_cycle_ns(&mut input, 80, 80)?; // init response
             for t in intervals.iter_mut() {
-                *t = next_cycle_ns(&mut input, 50_000, 26_000)?; // bit data
+                *t = next_cycle_ns(&mut input, 50, 26)?; // bit data
             }
         }
 


### PR DESCRIPTION
Epoll strangely cannot capture events duration properly most of the time.

Reverts back to a simpler value checking, with as much sleeping as possible given insight about periods caracteristics.